### PR TITLE
Improve terminal output readability and navigation

### DIFF
--- a/cv.html
+++ b/cv.html
@@ -6,6 +6,12 @@
     <title>Nami Shah – CV</title>
     <meta name="robots" content="noindex" />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700&family=Sora:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <main id="cv"></main>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,20 @@
     <link rel="icon" href="/favicon.ico" />
   </head>
   <body>
+    <!-- Decorative "electric pulse" comets behind the terminal: bright
+         glowing heads with long fading tails that zap along the background
+         grid's own lines (offsets are exact multiples of the grid's 44px
+         tile). Vertical ones drop down columns, horizontal ones sweep
+         across rows, each with its own speed/length/delay so they feel like
+         stray current, not a synchronized pattern. Purely visual:
+         aria-hidden and pointer-events:none (see terminal.css). -->
+    <div class="bg-rain" aria-hidden="true">
+      <span class="rain-trail" style="left: 132px; height: 380px; animation-duration: 7.4s; animation-delay: 0s;"></span>
+      <span class="rain-trail" style="left: 616px; height: 300px; animation-duration: 9.8s; animation-delay: 4.3s;"></span>
+      <span class="rain-trail" style="left: 1364px; height: 440px; animation-duration: 8.1s; animation-delay: 2.2s;"></span>
+      <span class="rain-trail trail-h" style="top: 176px; width: 420px; animation-duration: 10.6s; animation-delay: 6.1s;"></span>
+      <span class="rain-trail trail-h" style="top: 748px; width: 480px; animation-duration: 8.9s; animation-delay: 3.2s;"></span>
+    </div>
     <div id="app"></div>
     <noscript>
       <div style="max-width:720px;margin:40px auto;padding:0 16px;font-family:sans-serif;color:#eee">

--- a/src/cv/render.ts
+++ b/src/cv/render.ts
@@ -60,11 +60,12 @@ export function renderCV(root: HTMLElement) {
   // Projects
   root.appendChild(el("h2", "cv-h2", "Projects"));
   for (const p of cv.projects) {
+    const link = p.url ? ` ${p.url.replace("https://", "")}` : " (private repository)";
     root.appendChild(
       el(
         "p",
         "cv-p cv-project",
-        `${p.name} (${p.tech.slice(0, 3).join(", ")}) – ${p.description} ${p.url.replace("https://", "")}`,
+        `${p.name} (${p.tech.slice(0, 3).join(", ")}) – ${p.description}${link}`,
       ),
     );
   }

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -79,7 +79,6 @@ export const cv: CV = {
     },
     {
       name: "Ascend",
-      url: "https://github.com/OpenZeppelin/ascend-platform",
       tech: ["TypeScript", "Rust", "PostgreSQL", "Kubernetes"],
       description:
         "Institutional on-chain lending platform: identity and KYC rails, on-chain access control, event-sourced indexing, admin and client frontends.",

--- a/src/data/cv.ts
+++ b/src/data/cv.ts
@@ -136,7 +136,11 @@ export const cv: CV = {
       end: "2016",
     },
   ],
-  certifications: ["CREST Registered Penetration Tester (CRT)", "CREST Practitioner Security Analyst (CPSA)"],
+  certifications: [
+    "Management Essentials – Harvard Business School Online",
+    "CREST Registered Penetration Tester (CRT)",
+    "CREST Practitioner Security Analyst (CPSA)",
+  ],
   extras: {
     ctf: ["BruCON CTF 2015 – 2nd place", "HackTheFuture CTF 2015 – 3rd place", "Inter-ACE CTF 2018 – 9th place"],
   },

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -33,7 +33,8 @@ export interface ExperienceEntry {
 
 export interface Project {
   name: string;
-  url: string;
+  /** omit for private/proprietary repos - nothing to link to publicly */
+  url?: string;
   tech: string[];
   description: string;
   highlight?: string;

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -39,7 +39,7 @@ html, body { margin: 0; background: #e8e6e1; }
   color: var(--accent);
   border-bottom: 1px solid var(--rule);
   padding-bottom: 3pt;
-  margin: 17pt 0 8pt;
+  margin: 14pt 0 7pt;
 }
 
 .cv-p { font-size: 9pt; line-height: 1.62; margin: 0 0 5pt; }
@@ -81,7 +81,7 @@ html, body { margin: 0; background: #e8e6e1; }
     max-width: none;
     width: 210mm;
     min-height: auto;
-    padding: 16mm 17mm;
+    padding: 15mm 17mm;
   }
   .cv-toolbar { display: none; }
   a { color: inherit; text-decoration: none; }

--- a/src/styles/cv.css
+++ b/src/styles/cv.css
@@ -3,7 +3,12 @@
   --paper: #fafaf8;
   --accent: #c8380d;
   --rule: #d8d6d0;
-  --sans: "Helvetica Neue", Helvetica, Arial, sans-serif;
+  /* Falls back to the previous system stack if the webfont fails to load
+     (offline PDF generation, blocked network, etc.) - ATS text extraction
+     is unaffected either way since it reads the underlying glyph/Unicode
+     mapping, not the visual typeface. */
+  --sans: "Sora", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --mono-accent: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, Consolas, monospace;
 }
 
 html, body { margin: 0; background: #e8e6e1; }
@@ -22,32 +27,39 @@ html, body { margin: 0; background: #e8e6e1; }
 
 .cv-name {
   font-size: 26pt;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: -0.5pt;
   margin: 0 0 2pt;
   text-transform: uppercase;
 }
-.cv-headline { font-size: 10.5pt; font-weight: 700; color: var(--accent); margin: 0 0 5pt; }
+.cv-headline {
+  font-family: var(--mono-accent);
+  font-size: 9.5pt;
+  font-weight: 500;
+  color: var(--accent);
+  margin: 0 0 5pt;
+}
 .cv-contact { font-size: 8.5pt; color: #444; margin: 0; }
 .cv-header { border-bottom: 2px solid var(--ink); padding-bottom: 14pt; }
 
 .cv-h2 {
+  font-family: var(--mono-accent);
   font-size: 8.5pt;
-  font-weight: 800;
-  letter-spacing: 1.5pt;
+  font-weight: 700;
+  letter-spacing: 1pt;
   text-transform: uppercase;
   color: var(--accent);
   border-bottom: 1px solid var(--rule);
   padding-bottom: 3pt;
-  margin: 14pt 0 7pt;
+  margin: 12pt 0 6pt;
 }
 
-.cv-p { font-size: 9pt; line-height: 1.62; margin: 0 0 5pt; }
-.cv-entry { margin-bottom: 11pt; }
-.cv-entry-title { font-size: 10pt; font-weight: 700; margin: 6pt 0 3pt; }
+.cv-p { font-size: 9pt; line-height: 1.5; margin: 0 0 5pt; }
+.cv-entry { margin-bottom: 9pt; }
+.cv-entry-title { font-size: 10pt; font-weight: 700; margin: 5pt 0 3pt; }
 .cv-promotions { font-size: 8pt; color: #555; margin: 0 0 4pt; }
-.cv-bullets { margin: 5pt 0 0; padding-left: 14pt; }
-.cv-bullet { font-size: 9pt; line-height: 1.62; margin-bottom: 4pt; }
+.cv-bullets { margin: 4pt 0 0; padding-left: 14pt; }
+.cv-bullet { font-size: 9pt; line-height: 1.5; margin-bottom: 3pt; }
 .cv-condensed, .cv-earlier { color: #333; }
 .cv-earlier { font-size: 8pt; color: #555; margin-top: 4pt; }
 
@@ -81,7 +93,7 @@ html, body { margin: 0; background: #e8e6e1; }
     max-width: none;
     width: 210mm;
     min-height: auto;
-    padding: 15mm 17mm;
+    padding: 13mm 17mm;
   }
   .cv-toolbar { display: none; }
   a { color: inherit; text-decoration: none; }

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -17,9 +17,152 @@
 html, body {
   margin: 0;
   height: 100%;
-  background: var(--bg);
   color: var(--fg);
   font-family: var(--mono);
+}
+/* Background lives on `html`, not `body`: `body` doesn't establish a
+   stacking context, so its own solid background paints in the normal
+   in-flow-descendants step, which comes AFTER the negative z-index
+   pseudo-elements below - it would silently paint over them regardless of
+   their opacity. `html` IS the root stacking context, so its background
+   paints first, before anything with a negative z-index. */
+html { background: var(--bg); }
+
+/* Blueprint-style grid covering the full viewport. It's only ever visible
+   in the margins around the (opaque) terminal panel, so there's no mask
+   fading it out there - that would hide it exactly where it can be seen and
+   concentrate it exactly where the panel already blocks it. Negative
+   z-index keeps it behind #app without needing any markup or stacking
+   changes there. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(92, 207, 230, 0.016) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(92, 207, 230, 0.016) 1px, transparent 1px);
+  background-size: 44px 44px;
+}
+/* Electric pulses: comet-style streaks (markup in index.html) that zap
+   along the grid's own lines - vertical ones drop down columns, horizontal
+   ones sweep across rows. Each is a bright point-like head with a strong
+   radial glow and a long tail that fades smoothly to nothing (many
+   closely-spaced gradient stops approximating an exponential falloff, so
+   there's no visible "start edge" anywhere). The actual sweep is squeezed
+   into the first ~26% of each cycle; for the remaining ~74% the pulse rests
+   off-screen, so each line zaps quickly and then stays dark for several
+   seconds before its pulse comes around again. */
+.bg-rain {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  overflow: hidden;
+}
+.rain-trail {
+  position: absolute;
+  top: 0;
+  width: 1px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    rgba(92, 207, 230, 0.01) 30%,
+    rgba(92, 207, 230, 0.03) 50%,
+    rgba(92, 207, 230, 0.07) 66%,
+    rgba(92, 207, 230, 0.13) 79%,
+    rgba(96, 210, 232, 0.22) 88%,
+    rgba(108, 216, 236, 0.38) 94%,
+    rgba(126, 222, 239, 0.6) 98%,
+    rgba(150, 228, 242, 0.85) 100%
+  );
+  /* Overshoot by more than the head-halo radius (20px) so a pulse resting
+     at its start/end keyframe - or still waiting out its initial delay -
+     is entirely off-screen, glow included, instead of peeking in at the
+     viewport edge. */
+  transform: translateY(calc(-100% - 48px));
+  animation-name: pulse-v;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+}
+/* The comet head: a small bright core sitting on the leading tip... */
+.rain-trail::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -2px;
+  width: 3px;
+  height: 5px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: rgba(210, 245, 250, 0.95);
+}
+/* ...wrapped in a generous radial glow that radiates well beyond the line,
+   like the bloom around a point of light. */
+.rain-trail::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -20px;
+  width: 40px;
+  height: 40px;
+  transform: translateX(-50%);
+  background: radial-gradient(
+    circle,
+    rgba(160, 232, 244, 0.5) 0%,
+    rgba(110, 214, 235, 0.22) 35%,
+    rgba(92, 207, 230, 0.08) 55%,
+    transparent 72%
+  );
+}
+/* Horizontal variant: same anatomy rotated - tail fades to the left, head
+   leads on the right, sweeping across a horizontal grid line. */
+.rain-trail.trail-h {
+  width: auto;
+  height: 1px;
+  left: 0;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    rgba(92, 207, 230, 0.01) 30%,
+    rgba(92, 207, 230, 0.03) 50%,
+    rgba(92, 207, 230, 0.07) 66%,
+    rgba(92, 207, 230, 0.13) 79%,
+    rgba(96, 210, 232, 0.22) 88%,
+    rgba(108, 216, 236, 0.38) 94%,
+    rgba(126, 222, 239, 0.6) 98%,
+    rgba(150, 228, 242, 0.85) 100%
+  );
+  transform: translateX(calc(-100% - 48px));
+  animation-name: pulse-h;
+}
+.rain-trail.trail-h::after {
+  left: auto;
+  right: -2px;
+  bottom: 50%;
+  width: 5px;
+  height: 3px;
+  transform: translateY(50%);
+}
+.rain-trail.trail-h::before {
+  left: auto;
+  right: -20px;
+  bottom: 50%;
+  transform: translateY(50%);
+}
+@keyframes pulse-v {
+  0% { transform: translateY(calc(-100% - 48px)); }
+  26% { transform: translateY(calc(100vh + 48px)); }
+  100% { transform: translateY(calc(100vh + 48px)); }
+}
+@keyframes pulse-h {
+  0% { transform: translateX(calc(-100% - 48px)); }
+  26% { transform: translateX(calc(100vw + 48px)); }
+  100% { transform: translateX(calc(100vw + 48px)); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .rain-trail { animation: none; opacity: 0; }
 }
 
 #app { height: 100%; display: flex; justify-content: center; padding: 24px; }
@@ -107,6 +250,7 @@ html, body {
 .line-heading { color: var(--bright); font-weight: 700; }
 .line-accent { color: var(--green); }
 .line-muted { color: var(--muted); }
+.line-hint { margin-top: 10px; }
 .line-error { color: var(--red); }
 .line-link a { color: var(--accent); }
 .line-echo {

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -120,10 +120,13 @@ html, body {
 .echo-rule { color: var(--border); }
 .echo-prompt { color: var(--accent); }
 .echo-rule-fill { flex: 1 1 auto; height: 1px; background: var(--border); }
-/* CSS padding (not literal leading spaces) so wrapped continuation lines
-   stay aligned under the first line, and link underlines never cover
-   the indent whitespace. */
-.line-indent { padding-left: 2ch; }
+/* CSS padding (not literal leading spaces) so a wrapped continuation line
+   stays aligned under the text after the glyph, not under the glyph itself -
+   width matches "├── "/"└── " (4 monospace chars). Link underlines also never
+   cover this padding since the glyph is a separate span, not part of the
+   text/anchor. */
+.line-tree { padding-left: 4ch; }
+.tree-glyph { color: var(--border); }
 
 .scroll-bottom-btn {
   position: absolute;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -118,8 +118,8 @@ html, body {
   color: var(--bright);
 }
 .line-echo:first-child { margin-top: 0; }
-.echo-rule { color: var(--border); }
 .echo-prompt { color: var(--accent); }
+.text-dim { color: var(--border); }
 .echo-rule-fill { flex: 1 1 auto; height: 1px; background: var(--border); }
 /* When the command below opens with a tree, grow its trunk out of the rule
    line itself (from the vertical middle down to the next row, where the

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -110,6 +110,7 @@ html, body {
 .line-error { color: var(--red); }
 .line-link a { color: var(--accent); }
 .line-echo {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -120,15 +121,56 @@ html, body {
 .echo-rule { color: var(--border); }
 .echo-prompt { color: var(--accent); }
 .echo-rule-fill { flex: 1 1 auto; height: 1px; background: var(--border); }
-/* Hanging indent: padding-left reserves 4ch (matching "├── "/"└── ", 4
-   monospace chars) for every line, then text-indent pulls just the first
-   line back out by that same amount so the glyph starts flush at the edge -
-   only a wrapped continuation line (which text-indent doesn't touch) actually
-   lands on that padding, aligned under the text rather than under the glyph.
-   Link underlines also never cover it since the glyph is a separate span,
-   not part of the text/anchor. */
-.line-tree { padding-left: 4ch; text-indent: -4ch; }
-.tree-glyph { color: var(--border); }
+/* When the command below opens with a tree, grow its trunk out of the rule
+   line itself (from the vertical middle down to the next row, where the
+   first branch's own column continues it) instead of starting the pipe out
+   of nowhere a couple of rows down. */
+.line-echo.has-tree::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+}
+
+/* Each tree column is real geometry, not a character glyph: it's absolutely
+   positioned and sized to exactly this row's own box (full height by
+   default), so consecutive rows' columns tile into one continuous "│" with
+   no gap, no matter how tall `line-height` makes any single row. An ancestor
+   column that already closed (`.tree-closed`) draws nothing - a real `tree`
+   leaves blank space under a closed branch, not a dangling pipe. Only the
+   deepest column (`.tree-branch`, this line's own position among its
+   siblings) gets the horizontal tick that reaches out to the text; if that
+   position was the last child (`.tree-last`) its vertical half stops at the
+   tick instead of continuing the full row. */
+.tree-col {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 4ch; /* matches TREE_COL_CH in ui.ts */
+}
+.tree-col::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+}
+.tree-col.tree-closed::before { display: none; }
+.tree-col.tree-branch.tree-last::before { bottom: auto; height: 0.825em; }
+.tree-col.tree-branch::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.825em;
+  width: 3ch;
+  height: 1px;
+  background: var(--border);
+}
 
 .scroll-bottom-btn {
   position: absolute;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -25,6 +25,7 @@ html, body {
 #app { height: 100%; display: flex; justify-content: center; padding: 24px; }
 
 .term {
+  position: relative; /* anchors .scroll-bottom-btn to the panel */
   width: min(920px, 100%);
   height: min(720px, calc(100vh - 48px));
   background: var(--panel);
@@ -60,7 +61,7 @@ html, body {
 }
 .cv-btn:hover { filter: brightness(1.1); }
 
-.term-chips { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px 14px 0; }
+.term-chips { display: flex; flex-wrap: wrap; gap: 6px; padding: 10px 14px 14px; border-bottom: 1px solid var(--border); }
 .chip {
   background: transparent;
   border: 1px solid var(--border);
@@ -74,13 +75,33 @@ html, body {
 .chip:hover { color: var(--accent); border-color: var(--accent); }
 
 .term-output {
+  position: relative; /* makes child `.offsetTop` reads relative to this scroll container, not <body> */
   flex: 1;
   overflow-y: auto;
   padding: 14px;
+  /* Scroll headroom: without this, a command whose own output is shorter
+     than the panel (e.g. `education` as the last thing run) can't be
+     scrolled all the way to the top – the browser clamps scrollTop so it
+     never shows blank space below the content, which left its rule line
+     stuck mid-panel instead of flush at the top like every other command. */
+  padding-bottom: 50vh;
   font-size: 13.5px;
   line-height: 1.65;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+@keyframes stream-in {
+  from { opacity: 0; transform: translateY(4px); filter: blur(1.5px); }
+  60% { filter: blur(0); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.line {
+  opacity: 0;
+  animation: stream-in 240ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+@media (prefers-reduced-motion: reduce) {
+  .line { animation: none; opacity: 1; }
 }
 
 .line-heading { color: var(--bright); font-weight: 700; }
@@ -88,10 +109,44 @@ html, body {
 .line-muted { color: var(--muted); }
 .line-error { color: var(--red); }
 .line-link a { color: var(--accent); }
+.line-echo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 18px 0 6px;
+  color: var(--bright);
+}
+.line-echo:first-child { margin-top: 0; }
+.echo-rule { color: var(--border); }
+.echo-prompt { color: var(--accent); }
+.echo-rule-fill { flex: 1 1 auto; height: 1px; background: var(--border); }
 /* CSS padding (not literal leading spaces) so wrapped continuation lines
    stay aligned under the first line, and link underlines never cover
    the indent whitespace. */
 .line-indent { padding-left: 2ch; }
+
+.scroll-bottom-btn {
+  position: absolute;
+  right: 16px;
+  bottom: 60px;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: var(--panel);
+  color: var(--accent);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.45);
+  opacity: 0.9;
+  transition: opacity 120ms ease, transform 120ms ease, border-color 120ms ease;
+}
+.scroll-bottom-btn:hover { opacity: 1; border-color: var(--accent); transform: translateY(2px); }
+.scroll-bottom-btn[hidden] { display: none; }
 
 .term-prompt-row {
   display: flex;

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -120,12 +120,14 @@ html, body {
 .echo-rule { color: var(--border); }
 .echo-prompt { color: var(--accent); }
 .echo-rule-fill { flex: 1 1 auto; height: 1px; background: var(--border); }
-/* CSS padding (not literal leading spaces) so a wrapped continuation line
-   stays aligned under the text after the glyph, not under the glyph itself -
-   width matches "├── "/"└── " (4 monospace chars). Link underlines also never
-   cover this padding since the glyph is a separate span, not part of the
-   text/anchor. */
-.line-tree { padding-left: 4ch; }
+/* Hanging indent: padding-left reserves 4ch (matching "├── "/"└── ", 4
+   monospace chars) for every line, then text-indent pulls just the first
+   line back out by that same amount so the glyph starts flush at the edge -
+   only a wrapped continuation line (which text-indent doesn't touch) actually
+   lands on that padding, aligned under the text rather than under the glyph.
+   Link underlines also never cover it since the glyph is a separate span,
+   not part of the text/anchor. */
+.line-tree { padding-left: 4ch; text-indent: -4ch; }
 .tree-glyph { color: var(--border); }
 
 .scroll-bottom-btn {

--- a/src/terminal/commands.ts
+++ b/src/terminal/commands.ts
@@ -13,6 +13,10 @@ export interface Line {
    * last keeps drawing "│" straight through this row; one that was last
    * leaves that column blank, since its own branch already closed above. */
   treePath?: boolean[];
+  /** [start, end) character range of `text` to render in the dim border
+   * color instead of the line's normal color - used for the `help` fill
+   * dots, which read as a heavy wall of periods at full contrast. */
+  dimRange?: [number, number];
 }
 export interface CommandResult {
   lines: Line[];
@@ -85,7 +89,7 @@ function projects(): CommandResult {
     node(h(p.name + (p.highlight ? `  (${p.highlight})` : "")), [
       m(p.tech.join(" · ")),
       t(p.description),
-      link(p.url, p.url),
+      ...(p.url ? [link(p.url, p.url)] : [m("private repository")]),
     ]),
   );
   return { lines: flattenTree(nodes) };
@@ -118,7 +122,18 @@ function help(): CommandResult {
     ["clear", "clear the screen"],
     ["help", "this list"],
   ];
-  return { lines: rows.map(([cmd, desc]) => t(`${cmd.padEnd(12)} ${desc}`)) };
+  // Dot-fill each row out to a shared column, `man`-page style, so the
+  // descriptions line up regardless of command name length. The fill itself
+  // is dimmed to the same color as the tree glyphs so it recedes rather than
+  // competing with the command name and description for attention.
+  const col = Math.max(...rows.map(([cmd]) => cmd.length)) + 6;
+  const nodes = rows.map(([cmd, desc]) => {
+    const fill = ".".repeat(col - cmd.length);
+    const line = t(`${cmd}${fill}${desc}`);
+    line.dimRange = [cmd.length, cmd.length + fill.length];
+    return node(line);
+  });
+  return { lines: flattenTree(nodes) };
 }
 
 const registry: Record<string, () => CommandResult> = {

--- a/src/terminal/commands.ts
+++ b/src/terminal/commands.ts
@@ -59,20 +59,24 @@ function experience(): CommandResult {
 
 function projects(): CommandResult {
   const lines: Line[] = [];
-  for (const p of cv.projects) {
+  cv.projects.forEach((p, i) => {
+    if (i > 0) lines.push(blank());
     lines.push(h(p.name + (p.highlight ? `  (${p.highlight})` : "")));
     lines.push(m(p.tech.join(" · ")));
     lines.push(indent(t(p.description)));
     lines.push(indent(link(p.url, p.url)));
-    lines.push(blank());
-  }
+  });
   return { lines };
 }
 
 function skills(): CommandResult {
-  return {
-    lines: cv.skills.flatMap((g) => [h(g.label), indent(t(g.items.join(" · "))), blank()]),
-  };
+  const lines: Line[] = [];
+  cv.skills.forEach((g, i) => {
+    if (i > 0) lines.push(blank());
+    lines.push(h(g.label));
+    lines.push(indent(t(g.items.join(" · "))));
+  });
+  return { lines };
 }
 
 function education(): CommandResult {

--- a/src/terminal/commands.ts
+++ b/src/terminal/commands.ts
@@ -5,10 +5,12 @@ export interface Line {
   text: string;
   kind: LineKind;
   href?: string;
-  /** Applies a consistent CSS left-padding so wrapped continuation lines
-   * stay aligned under the first line (literal leading spaces don't
-   * survive line-wrapping, and would also get underlined on link lines). */
-  indent?: boolean;
+  /** Renders as a `tree`-style branch under the heading above it ("mid" ->
+   * "├── ", "last" -> "└── "), instead of a "- " bullet or bare indent. The
+   * glyph is drawn by the UI layer (not baked into `text`) so it can be its
+   * own dim span - keeping it out of link anchors and out of the coloring
+   * for the line's `kind`. */
+  branch?: "mid" | "last";
 }
 export interface CommandResult {
   lines: Line[];
@@ -21,7 +23,13 @@ const m = (text: string): Line => ({ text, kind: "muted" });
 const a = (text: string): Line => ({ text, kind: "accent" });
 const link = (text: string, href: string): Line => ({ text, kind: "link", href });
 const blank = (): Line => ({ text: "", kind: "text" });
-const indent = (line: Line): Line => ({ ...line, indent: true });
+
+/** Marks `line` as a tree branch (see `Line.branch`); pass whether it's the
+ * last child in its group so the glyph switches from "├── " to "└── ". */
+const branch = (line: Line, isLast: boolean): Line => ({ ...line, branch: isLast ? "last" : "mid" });
+/** Tags every line in `group` as tree branches, letting the group figure out
+ * for itself which one is last - avoids every call site re-deriving that. */
+const branches = (group: Line[]): Line[] => group.map((line, i) => branch(line, i === group.length - 1));
 
 function whoami(): CommandResult {
   return {
@@ -50,7 +58,7 @@ function experience(): CommandResult {
     } else {
       lines.push(a(first.title));
     }
-    for (const b of e.bullets) lines.push(indent(t(`- ${b}`)));
+    lines.push(...branches(e.bullets.map((b) => t(b))));
     lines.push(blank());
   }
   lines.push(m(cv.earlierRoles));
@@ -62,9 +70,7 @@ function projects(): CommandResult {
   cv.projects.forEach((p, i) => {
     if (i > 0) lines.push(blank());
     lines.push(h(p.name + (p.highlight ? `  (${p.highlight})` : "")));
-    lines.push(m(p.tech.join(" · ")));
-    lines.push(indent(t(p.description)));
-    lines.push(indent(link(p.url, p.url)));
+    lines.push(...branches([m(p.tech.join(" · ")), t(p.description), link(p.url, p.url)]));
   });
   return { lines };
 }
@@ -74,7 +80,7 @@ function skills(): CommandResult {
   cv.skills.forEach((g, i) => {
     if (i > 0) lines.push(blank());
     lines.push(h(g.label));
-    lines.push(indent(t(g.items.join(" · "))));
+    lines.push(branch(t(g.items.join(" · ")), true));
   });
   return { lines };
 }
@@ -83,14 +89,14 @@ function education(): CommandResult {
   const lines: Line[] = [];
   for (const e of cv.education) {
     lines.push(h(`${e.school}  [${e.start}–${e.end}]`));
-    lines.push(indent(t(`${e.degree} – ${e.detail}`)));
+    lines.push(branch(t(`${e.degree} – ${e.detail}`), true));
   }
   lines.push(blank());
   lines.push(h("Certifications"));
-  for (const c of cv.certifications) lines.push(indent(t(c)));
+  lines.push(...branches(cv.certifications.map((c) => t(c))));
   lines.push(blank());
   lines.push(h("CTF"));
-  for (const c of cv.extras.ctf) lines.push(indent(m(c)));
+  lines.push(...branches(cv.extras.ctf.map((c) => m(c))));
   return { lines };
 }
 

--- a/src/terminal/commands.ts
+++ b/src/terminal/commands.ts
@@ -5,12 +5,14 @@ export interface Line {
   text: string;
   kind: LineKind;
   href?: string;
-  /** Renders as a `tree`-style branch under the heading above it ("mid" ->
-   * "├── ", "last" -> "└── "), instead of a "- " bullet or bare indent. The
-   * glyph is drawn by the UI layer (not baked into `text`) so it can be its
-   * own dim span - keeping it out of link anchors and out of the coloring
-   * for the line's `kind`. */
-  branch?: "mid" | "last";
+  /** For tree-rendered lines: this line's position among its own siblings at
+   * every depth from the root down to itself - index i says whether the
+   * ancestor at depth i (or, for the last index, this line itself) was the
+   * LAST child among ITS siblings. The UI uses this to draw a `tree`-style
+   * set of connected branches at arbitrary depth: an ancestor that wasn't
+   * last keeps drawing "│" straight through this row; one that was last
+   * leaves that column blank, since its own branch already closed above. */
+  treePath?: boolean[];
 }
 export interface CommandResult {
   lines: Line[];
@@ -24,91 +26,85 @@ const a = (text: string): Line => ({ text, kind: "accent" });
 const link = (text: string, href: string): Line => ({ text, kind: "link", href });
 const blank = (): Line => ({ text: "", kind: "text" });
 
-/** Marks `line` as a tree branch (see `Line.branch`); pass whether it's the
- * last child in its group so the glyph switches from "├── " to "└── ". */
-const branch = (line: Line, isLast: boolean): Line => ({ ...line, branch: isLast ? "last" : "mid" });
-/** Tags every line in `group` as tree branches, letting the group figure out
- * for itself which one is last - avoids every call site re-deriving that. */
-const branches = (group: Line[]): Line[] => group.map((line, i) => branch(line, i === group.length - 1));
+/** A node in a lightweight tree built up before flattening to `Line[]` -
+ * mirrors how `tree` itself groups a heading (a company, a project, a skill
+ * group...) with its detail lines nested underneath it. */
+interface TreeNode {
+  line: Line;
+  children?: TreeNode[];
+}
+const node = (line: Line, children: Line[] = []): TreeNode => ({
+  line,
+  children: children.map((line) => ({ line })),
+});
+
+/** Flattens sibling `TreeNode`s (depth-first) into `Line[]`, stamping each
+ * with the `treePath` the UI needs to draw connected branches - see
+ * `Line.treePath`. No blank lines between entries by design: a real `tree`
+ * never inserts them either, and blank rows would break the vertical pipe's
+ * continuity between siblings. */
+function flattenTree(nodes: TreeNode[], ancestorPath: boolean[] = []): Line[] {
+  const lines: Line[] = [];
+  nodes.forEach((n, i) => {
+    const path = [...ancestorPath, i === nodes.length - 1];
+    lines.push({ ...n.line, treePath: path });
+    if (n.children?.length) lines.push(...flattenTree(n.children, path));
+  });
+  return lines;
+}
 
 function whoami(): CommandResult {
-  return {
-    lines: [
-      h(cv.profile.name),
+  const nodes = [
+    node(h(cv.profile.name), [
       a(cv.profile.headline),
       m(cv.profile.location),
-      blank(),
       t(cv.profile.summary),
-      blank(),
       ...cv.profile.links.map((l) => link(l.label, l.url)),
-      m("email: run `contact`"),
-    ],
-  };
+      // The obfuscated address is decoded on click in the UI layer; here we
+      // only expose a label so the raw address never sits in the DOM.
+      link("email (click to reveal)", `obfuscated:${cv.profile.emailObfuscated}`),
+    ]),
+  ];
+  return { lines: flattenTree(nodes) };
 }
 
 function experience(): CommandResult {
-  const lines: Line[] = [];
-  for (const e of cv.experience) {
+  const nodes = cv.experience.map((e) => {
     const first = e.roles[0]!;
     const last = e.roles[e.roles.length - 1]!;
     const span = `${last.start} – ${first.end ?? "Present"}`;
-    lines.push(h(`${e.company}  [${span}]`));
-    if (e.roles.length > 1) {
-      lines.push(a(e.roles.map((r) => r.title).reverse().join(" → ")));
-    } else {
-      lines.push(a(first.title));
-    }
-    lines.push(...branches(e.bullets.map((b) => t(b))));
-    lines.push(blank());
-  }
-  lines.push(m(cv.earlierRoles));
-  return { lines };
+    const roleLine =
+      e.roles.length > 1 ? a(e.roles.map((r) => r.title).reverse().join(" → ")) : a(first.title);
+    return node(h(`${e.company}  [${span}]`), [roleLine, ...e.bullets.map((b) => t(b))]);
+  });
+  return { lines: [...flattenTree(nodes), blank(), m(cv.earlierRoles)] };
 }
 
 function projects(): CommandResult {
-  const lines: Line[] = [];
-  cv.projects.forEach((p, i) => {
-    if (i > 0) lines.push(blank());
-    lines.push(h(p.name + (p.highlight ? `  (${p.highlight})` : "")));
-    lines.push(...branches([m(p.tech.join(" · ")), t(p.description), link(p.url, p.url)]));
-  });
-  return { lines };
+  const nodes = cv.projects.map((p) =>
+    node(h(p.name + (p.highlight ? `  (${p.highlight})` : "")), [
+      m(p.tech.join(" · ")),
+      t(p.description),
+      link(p.url, p.url),
+    ]),
+  );
+  return { lines: flattenTree(nodes) };
 }
 
 function skills(): CommandResult {
-  const lines: Line[] = [];
-  cv.skills.forEach((g, i) => {
-    if (i > 0) lines.push(blank());
-    lines.push(h(g.label));
-    lines.push(branch(t(g.items.join(" · ")), true));
-  });
-  return { lines };
+  const nodes = cv.skills.map((g) => node(h(g.label), [t(g.items.join(" · "))]));
+  return { lines: flattenTree(nodes) };
 }
 
 function education(): CommandResult {
-  const lines: Line[] = [];
-  for (const e of cv.education) {
-    lines.push(h(`${e.school}  [${e.start}–${e.end}]`));
-    lines.push(branch(t(`${e.degree} – ${e.detail}`), true));
-  }
-  lines.push(blank());
-  lines.push(h("Certifications"));
-  lines.push(...branches(cv.certifications.map((c) => t(c))));
-  lines.push(blank());
-  lines.push(h("CTF"));
-  lines.push(...branches(cv.extras.ctf.map((c) => m(c))));
-  return { lines };
-}
-
-function contact(): CommandResult {
-  return {
-    lines: [
-      // The obfuscated address is decoded on click in the UI layer (Task 4);
-      // here we only expose a label so the raw address never sits in the DOM.
-      link("email (click to reveal)", `obfuscated:${cv.profile.emailObfuscated}`),
-      ...cv.profile.links.map((l) => link(l.label, l.url)),
-    ],
-  };
+  const nodes = [
+    ...cv.education.map((e) =>
+      node(h(`${e.school}  [${e.start}–${e.end}]`), [t(`${e.degree} – ${e.detail}`)]),
+    ),
+    node(h("Certifications"), cv.certifications.map((c) => t(c))),
+    node(h("CTF"), cv.extras.ctf.map((c) => m(c))),
+  ];
+  return { lines: flattenTree(nodes) };
 }
 
 function help(): CommandResult {
@@ -118,7 +114,6 @@ function help(): CommandResult {
     ["projects", "featured projects"],
     ["skills", "technical skills"],
     ["education", "degrees, certs, CTFs"],
-    ["contact", "how to reach me"],
     ["cv", "open the printable one-page CV"],
     ["clear", "clear the screen"],
     ["help", "this list"],
@@ -132,19 +127,18 @@ const registry: Record<string, () => CommandResult> = {
   projects,
   skills,
   education,
-  contact,
   help,
   cv: () => ({ lines: [m("opening cv...")], action: "open-cv" }),
   clear: () => ({ lines: [], action: "clear" }),
   ls: () => ({
-    lines: [t("experience/  projects/  skills/  education/  contact/  nami-shah-cv.pdf")],
+    lines: [t("experience/  projects/  skills/  education/  nami-shah-cv.pdf")],
   }),
   sudo: () => ({
     lines: [a("Nice try. This incident will be reported... to my inbox, where I'll happily read it.")],
   }),
 };
 
-export const COMMAND_NAMES = ["whoami", "experience", "projects", "skills", "education", "contact", "cv", "clear", "help"];
+export const COMMAND_NAMES = ["whoami", "experience", "projects", "skills", "education", "cv", "clear", "help"];
 
 export function runCommand(input: string): CommandResult {
   const word = input.trim().split(/\s+/)[0]?.toLowerCase() ?? "";

--- a/src/terminal/ui.ts
+++ b/src/terminal/ui.ts
@@ -3,6 +3,8 @@ import { runCommand, COMMAND_NAMES, type Line } from "./commands";
 const PROMPT = "nami@sh:~$";
 /** Stagger, in ms, between consecutive output lines "streaming" in on a command run. */
 const STREAM_STEP_MS = 16;
+/** Width of one tree-depth column, matching "├── "/"└── " (glyph + gap before text). */
+const TREE_COL_CH = 4;
 
 export class Terminal {
   private output: HTMLElement;
@@ -139,6 +141,10 @@ export class Terminal {
       window.location.href = "/cv.html";
       return;
     }
+    // If the output opens with a tree, grow its trunk down from the rule
+    // line itself, so the tree visibly hangs off the command that produced
+    // it rather than starting out of nowhere a couple of lines down.
+    if (echoEl && result.lines[0]?.treePath) echoEl.classList.add("has-tree");
     result.lines.forEach((l, i) => this.printLine(l, i * STREAM_STEP_MS));
     // Scroll only after every line is in the DOM – doing it right after the
     // echo line was appended clamped scrollTop back down because the
@@ -235,19 +241,37 @@ export class Terminal {
    * matrix-style reveal that also makes it obvious when a command's
    * output has finished (the streaming stops).
    */
+  /**
+   * Draws this line's tree columns as absolutely-positioned overlays rather
+   * than baked-in "├── "/"└── " characters, so the connecting pipe is real
+   * geometry (each column spans exactly this row's box, full height by
+   * default) instead of a character glyph that leaves a gap whenever
+   * `line-height` adds space above/below it. Consecutive rows' columns then
+   * tile into one continuous line automatically, at any depth, since there's
+   * no margin between `.line` elements. Only the deepest column (this line's
+   * own branch) gets a horizontal tick and, if it's the last child, stops
+   * its vertical half-way instead of running the full row height.
+   */
+  private renderTreeColumns(el: HTMLElement, path: boolean[]) {
+    const depth = path.length - 1;
+    el.style.position = "relative";
+    el.style.paddingLeft = `${(depth + 1) * TREE_COL_CH}ch`;
+    path.forEach((isLast, i) => {
+      const isOwnColumn = i === depth;
+      const col = document.createElement("span");
+      col.className = isOwnColumn
+        ? `tree-col tree-branch${isLast ? " tree-last" : ""}`
+        : `tree-col${isLast ? " tree-closed" : ""}`;
+      col.style.left = `${i * TREE_COL_CH}ch`;
+      el.appendChild(col);
+    });
+  }
+
   printLine(line: Line, delayMs = 0) {
     const el = document.createElement("div");
-    el.className = `line line-${line.kind}${line.branch ? " line-tree" : ""}`;
+    el.className = `line line-${line.kind}`;
     if (delayMs) el.style.animationDelay = `${delayMs}ms`;
-    if (line.branch) {
-      // A separate span (not baked into the text/anchor) so the glyph can be
-      // dimmed independently of the line's colour and never ends up inside -
-      // and therefore underlined by - a link.
-      const glyph = document.createElement("span");
-      glyph.className = "tree-glyph";
-      glyph.textContent = line.branch === "last" ? "└── " : "├── ";
-      el.appendChild(glyph);
-    }
+    if (line.treePath) this.renderTreeColumns(el, line.treePath);
     if (line.kind === "link" && line.href) {
       const a = document.createElement("a");
       if (line.href.startsWith("obfuscated:")) {
@@ -276,14 +300,15 @@ export class Terminal {
   /** Boot: type `whoami` character by character, then run it. */
   async boot() {
     const cmd = "whoami";
+    const result = runCommand(cmd);
     await new Promise((r) => setTimeout(r, 550));
-    const { cmdSpan } = this.appendEchoLine();
+    const { el: echoEl, cmdSpan } = this.appendEchoLine();
+    if (result.lines[0]?.treePath) echoEl.classList.add("has-tree");
     for (let i = 1; i <= cmd.length; i++) {
       cmdSpan.textContent = cmd.slice(0, i);
       await new Promise((r) => setTimeout(r, 120));
     }
     await new Promise((r) => setTimeout(r, 900));
-    const result = runCommand(cmd);
     result.lines.forEach((l, i) => this.printLine(l, i * STREAM_STEP_MS));
     this.printLine(
       { text: "type `help` or click a command above", kind: "muted" },

--- a/src/terminal/ui.ts
+++ b/src/terminal/ui.ts
@@ -237,8 +237,17 @@ export class Terminal {
    */
   printLine(line: Line, delayMs = 0) {
     const el = document.createElement("div");
-    el.className = `line line-${line.kind}${line.indent ? " line-indent" : ""}`;
+    el.className = `line line-${line.kind}${line.branch ? " line-tree" : ""}`;
     if (delayMs) el.style.animationDelay = `${delayMs}ms`;
+    if (line.branch) {
+      // A separate span (not baked into the text/anchor) so the glyph can be
+      // dimmed independently of the line's colour and never ends up inside -
+      // and therefore underlined by - a link.
+      const glyph = document.createElement("span");
+      glyph.className = "tree-glyph";
+      glyph.textContent = line.branch === "last" ? "└── " : "├── ";
+      el.appendChild(glyph);
+    }
     if (line.kind === "link" && line.href) {
       const a = document.createElement("a");
       if (line.href.startsWith("obfuscated:")) {
@@ -259,7 +268,7 @@ export class Terminal {
       }
       el.appendChild(a);
     } else {
-      el.textContent = line.text || "\u00a0";
+      el.appendChild(document.createTextNode(line.text || "\u00a0"));
     }
     this.output.appendChild(el);
   }

--- a/src/terminal/ui.ts
+++ b/src/terminal/ui.ts
@@ -194,22 +194,19 @@ export class Terminal {
   }
 
   /**
-   * Builds a labelled rule line, e.g. "── nami@sh:~$ experience ──────────",
-   * and appends it to the output. The leading dashes are static text but
-   * the trailing rule is a flex-grown div that stretches to the panel's
-   * edge, so it works at any width/font size. This doubles as the section
-   * separator (command outputs never end the same way, so a plain blank
-   * line was an inconsistent gap) and as the command echo, styled
-   * two-toned like the live prompt. Returns both the line and its command
-   * span so callers can fill the span in immediately (printCommandEcho),
-   * type into it over time (boot), or scroll the line into view.
+   * Builds a labelled rule line, e.g. "nami@sh:~$ experience ──────────",
+   * and appends it to the output. The trailing rule is a flex-grown div that
+   * stretches to the panel's edge, so it works at any width/font size. This
+   * doubles as the section separator (command outputs never end the same
+   * way, so a plain blank line was an inconsistent gap) and as the command
+   * echo, styled two-toned like the live prompt. Returns both the line and
+   * its command span so callers can fill the span in immediately
+   * (printCommandEcho), type into it over time (boot), or scroll the line
+   * into view.
    */
   private appendEchoLine(): { el: HTMLElement; cmdSpan: HTMLElement } {
     const el = document.createElement("div");
     el.className = "line line-echo";
-    const lead = document.createElement("span");
-    lead.className = "echo-rule";
-    lead.textContent = "──";
     const promptSpan = document.createElement("span");
     promptSpan.className = "echo-prompt";
     promptSpan.textContent = PROMPT;
@@ -217,7 +214,7 @@ export class Terminal {
     cmdSpan.className = "echo-cmd";
     const fill = document.createElement("span");
     fill.className = "echo-rule-fill";
-    el.append(lead, promptSpan, cmdSpan, fill);
+    el.append(promptSpan, cmdSpan, fill);
     this.output.appendChild(el);
     return { el, cmdSpan };
   }
@@ -291,6 +288,14 @@ export class Terminal {
         a.rel = "noopener";
       }
       el.appendChild(a);
+    } else if (line.dimRange) {
+      const [start, end] = line.dimRange;
+      el.appendChild(document.createTextNode(line.text.slice(0, start)));
+      const dim = document.createElement("span");
+      dim.className = "text-dim";
+      dim.textContent = line.text.slice(start, end);
+      el.appendChild(dim);
+      el.appendChild(document.createTextNode(line.text.slice(end)));
     } else {
       el.appendChild(document.createTextNode(line.text || "\u00a0"));
     }

--- a/src/terminal/ui.ts
+++ b/src/terminal/ui.ts
@@ -1,11 +1,14 @@
 import { runCommand, COMMAND_NAMES, type Line } from "./commands";
 
 const PROMPT = "nami@sh:~$";
+/** Stagger, in ms, between consecutive output lines "streaming" in on a command run. */
+const STREAM_STEP_MS = 16;
 
 export class Terminal {
   private output: HTMLElement;
   private input: HTMLInputElement;
   private suggest: HTMLElement;
+  private scrollBtn: HTMLButtonElement;
   private history: string[] = [];
   private historyIdx = -1;
 
@@ -19,6 +22,7 @@ export class Terminal {
         </header>
         <div class="term-chips" role="toolbar" aria-label="commands"></div>
         <div class="term-output" aria-live="polite"></div>
+        <button class="scroll-bottom-btn" aria-label="Scroll to bottom of output" hidden>&#8595;</button>
         <div class="term-prompt-row">
           <span class="term-prompt">${PROMPT}</span>
           <div class="term-input-wrap">
@@ -31,9 +35,12 @@ export class Terminal {
     this.output = this.root.querySelector(".term-output")!;
     this.input = this.root.querySelector(".term-input")!;
     this.suggest = this.root.querySelector(".term-suggest")!;
+    this.scrollBtn = this.root.querySelector(".scroll-bottom-btn")!;
     this.renderChips();
     this.bindInput();
     this.updateSuggestion();
+    this.output.addEventListener("scroll", () => this.updateScrollButton());
+    this.scrollBtn.addEventListener("click", () => this.scrollToContentBottom());
     this.root.querySelector(".term")!.addEventListener("click", (e) => {
       // clicking anywhere focuses the prompt, unless selecting text or clicking a link
       if ((e.target as HTMLElement).closest("a,button")) return;
@@ -115,14 +122,16 @@ export class Terminal {
 
   exec(raw: string) {
     const cmd = raw.trim();
+    let echoEl: HTMLElement | null = null;
     if (cmd) {
       this.history.push(cmd);
       this.historyIdx = this.history.length;
-      this.printLine({ text: `${PROMPT} ${cmd}`, kind: "muted" });
+      echoEl = this.printCommandEcho(cmd);
     }
     const result = runCommand(cmd);
     if (result.action === "clear") {
       this.output.innerHTML = "";
+      this.updateScrollButton();
       return;
     }
     if (result.action === "open-cv") {
@@ -130,13 +139,106 @@ export class Terminal {
       window.location.href = "/cv.html";
       return;
     }
-    for (const l of result.lines) this.printLine(l);
-    this.scrollToBottom();
+    result.lines.forEach((l, i) => this.printLine(l, i * STREAM_STEP_MS));
+    // Scroll only after every line is in the DOM – doing it right after the
+    // echo line was appended clamped scrollTop back down because the
+    // container wasn't tall enough yet to reach that offset.
+    if (echoEl) this.scrollEchoToTop(echoEl);
+    this.updateScrollButton();
   }
 
-  printLine(line: Line) {
+  /**
+   * Scrolling to exactly `echoEl.offsetTop` scrolls past `.term-output`'s
+   * own top padding, so only the very first command (where scrollTop is
+   * naturally still 0) kept that breathing room under the chips bar –
+   * every command after it landed with its rule line flush against the
+   * container edge. Subtracting the padding back out keeps that gap
+   * consistent no matter which command just ran.
+   */
+  private scrollEchoToTop(echoEl: HTMLElement) {
+    const paddingTop = parseFloat(getComputedStyle(this.output).paddingTop) || 0;
+    this.output.scrollTop = echoEl.offsetTop - paddingTop;
+  }
+
+  /**
+   * Shows a floating "scroll to bottom" affordance whenever the just-run
+   * command's output is taller than the visible area, so long outputs
+   * (e.g. `experience`) don't leave the rest of the content undiscoverable
+   * below the fold. Measured against the last real line's position, not
+   * `scrollHeight`, since `.term-output` carries a permanent bottom-padding
+   * buffer (scroll headroom, see terminal.css) that would otherwise always
+   * register as "more content below".
+   */
+  private updateScrollButton() {
+    const last = this.output.lastElementChild as HTMLElement | null;
+    if (!last) {
+      this.scrollBtn.hidden = true;
+      return;
+    }
+    const outputBottom = this.output.getBoundingClientRect().bottom;
+    const lastBottom = last.getBoundingClientRect().bottom;
+    this.scrollBtn.hidden = lastBottom <= outputBottom + 4;
+  }
+
+  private scrollToContentBottom() {
+    const last = this.output.lastElementChild as HTMLElement | null;
+    if (!last) return;
+    const target = last.offsetTop + last.offsetHeight - this.output.clientHeight;
+    this.output.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+  }
+
+  /**
+   * Builds a labelled rule line, e.g. "── nami@sh:~$ experience ──────────",
+   * and appends it to the output. The leading dashes are static text but
+   * the trailing rule is a flex-grown div that stretches to the panel's
+   * edge, so it works at any width/font size. This doubles as the section
+   * separator (command outputs never end the same way, so a plain blank
+   * line was an inconsistent gap) and as the command echo, styled
+   * two-toned like the live prompt. Returns both the line and its command
+   * span so callers can fill the span in immediately (printCommandEcho),
+   * type into it over time (boot), or scroll the line into view.
+   */
+  private appendEchoLine(): { el: HTMLElement; cmdSpan: HTMLElement } {
+    const el = document.createElement("div");
+    el.className = "line line-echo";
+    const lead = document.createElement("span");
+    lead.className = "echo-rule";
+    lead.textContent = "──";
+    const promptSpan = document.createElement("span");
+    promptSpan.className = "echo-prompt";
+    promptSpan.textContent = PROMPT;
+    const cmdSpan = document.createElement("span");
+    cmdSpan.className = "echo-cmd";
+    const fill = document.createElement("span");
+    fill.className = "echo-rule-fill";
+    el.append(lead, promptSpan, cmdSpan, fill);
+    this.output.appendChild(el);
+    return { el, cmdSpan };
+  }
+
+  /**
+   * Prints the rule line for a just-run command and returns it so `exec`
+   * can scroll it to the top of the visible area once the rest of that
+   * command's output has been appended too – you should always land on
+   * the start of what you just ran, not its tail end.
+   */
+  private printCommandEcho(cmd: string): HTMLElement {
+    const { el, cmdSpan } = this.appendEchoLine();
+    cmdSpan.textContent = cmd;
+    return el;
+  }
+
+  /**
+   * `delayMs` staggers this line's CSS reveal animation (see `.line` in
+   * terminal.css) so a command's output visibly "streams" in line by line
+   * rather than appearing all at once – a quick, readable stand-in for a
+   * matrix-style reveal that also makes it obvious when a command's
+   * output has finished (the streaming stops).
+   */
+  printLine(line: Line, delayMs = 0) {
     const el = document.createElement("div");
     el.className = `line line-${line.kind}${line.indent ? " line-indent" : ""}`;
+    if (delayMs) el.style.animationDelay = `${delayMs}ms`;
     if (line.kind === "link" && line.href) {
       const a = document.createElement("a");
       if (line.href.startsWith("obfuscated:")) {
@@ -160,28 +262,25 @@ export class Terminal {
       el.textContent = line.text || "\u00a0";
     }
     this.output.appendChild(el);
-    this.scrollToBottom();
-  }
-
-  private scrollToBottom() {
-    this.output.scrollTop = this.output.scrollHeight;
   }
 
   /** Boot: type `whoami` character by character, then run it. */
   async boot() {
     const cmd = "whoami";
     await new Promise((r) => setTimeout(r, 550));
-    const ghost = document.createElement("div");
-    ghost.className = "line line-muted";
-    this.output.appendChild(ghost);
+    const { cmdSpan } = this.appendEchoLine();
     for (let i = 1; i <= cmd.length; i++) {
-      ghost.textContent = `${PROMPT} ${cmd.slice(0, i)}`;
+      cmdSpan.textContent = cmd.slice(0, i);
       await new Promise((r) => setTimeout(r, 120));
     }
     await new Promise((r) => setTimeout(r, 900));
     const result = runCommand(cmd);
-    for (const l of result.lines) this.printLine(l);
-    this.printLine({ text: "type `help` or click a command above", kind: "muted" });
+    result.lines.forEach((l, i) => this.printLine(l, i * STREAM_STEP_MS));
+    this.printLine(
+      { text: "type `help` or click a command above", kind: "muted" },
+      result.lines.length * STREAM_STEP_MS,
+    );
+    this.updateScrollButton();
     this.input.focus();
   }
 }

--- a/src/terminal/ui.ts
+++ b/src/terminal/ui.ts
@@ -264,9 +264,9 @@ export class Terminal {
     });
   }
 
-  printLine(line: Line, delayMs = 0) {
+  printLine(line: Line, delayMs = 0, extraClass?: string) {
     const el = document.createElement("div");
-    el.className = `line line-${line.kind}`;
+    el.className = extraClass ? `line line-${line.kind} ${extraClass}` : `line line-${line.kind}`;
     if (delayMs) el.style.animationDelay = `${delayMs}ms`;
     if (line.treePath) this.renderTreeColumns(el, line.treePath);
     if (line.kind === "link" && line.href) {
@@ -318,6 +318,7 @@ export class Terminal {
     this.printLine(
       { text: "type `help` or click a command above", kind: "muted" },
       result.lines.length * STREAM_STEP_MS,
+      "line-hint",
     );
     this.updateScrollButton();
     this.input.focus();


### PR DESCRIPTION
## Summary
- Replace inconsistent blank-line separators between command outputs with a labeled rule (`── nami@sh:~$ <command> ──────`), applied consistently across the boot sequence and every command run
- Stream command output in line-by-line for a lightweight, matrix-style reveal (respects `prefers-reduced-motion`)
- Always scroll the just-run command's rule to the top of the visible viewport, instead of leaving it wherever the previous scroll position happened to land
- Add a floating "scroll to bottom" button that appears only when a command's output overflows the panel
- Add a bit more breathing room between the quick-action chips and the terminal output

## Test plan
- [x] `npm test` (13 tests passing)
- [x] `npm run build`
- [ ] Click through each quick-action chip and confirm the command's rule lands at the top of the panel every time, not just for the first command
- [ ] Run a long command (e.g. `experience`) and confirm the scroll-to-bottom button appears/disappears correctly
- [ ] Confirm output streams in smoothly, and disable "reduce motion" in OS settings to confirm the animation is skipped